### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
 rvm:
  - 2.7.1
+before_install: gem install bundler -v '<2'
+script: echo "no tests yet"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: osx
 language: ruby
 rvm:
  - 2.7.1


### PR DESCRIPTION
* Ruby 2.7.1 does not come with bundler 1.x, so we need to install it
* Since the project does not have any tests, let's just output a reminder to get nice and green status for now